### PR TITLE
Fix max clock collection in NVIDIA collector

### DIFF
--- a/collectors/nvidiaMetric.go
+++ b/collectors/nvidiaMetric.go
@@ -537,7 +537,7 @@ func readMaxClocks(device NvidiaCollectorDevice, output chan lp.CCMessage) error
 	}
 
 	if !device.excludeMetrics["nv_max_sm_clock"] {
-		maxSmClock, ret := nvml.DeviceGetClockInfo(device.device, nvml.CLOCK_SM)
+		maxSmClock, ret := nvml.DeviceGetMaxClockInfo(device.device, nvml.CLOCK_SM)
 		if ret == nvml.SUCCESS {
 			y, err := lp.NewMessage("nv_max_sm_clock", device.tags, device.meta, map[string]interface{}{"value": float64(maxSmClock)}, time.Now())
 			if err == nil {
@@ -548,7 +548,7 @@ func readMaxClocks(device NvidiaCollectorDevice, output chan lp.CCMessage) error
 	}
 
 	if !device.excludeMetrics["nv_max_mem_clock"] {
-		maxMemClock, ret := nvml.DeviceGetClockInfo(device.device, nvml.CLOCK_MEM)
+		maxMemClock, ret := nvml.DeviceGetMaxClockInfo(device.device, nvml.CLOCK_MEM)
 		if ret == nvml.SUCCESS {
 			y, err := lp.NewMessage("nv_max_mem_clock", device.tags, device.meta, map[string]interface{}{"value": float64(maxMemClock)}, time.Now())
 			if err == nil {
@@ -559,7 +559,7 @@ func readMaxClocks(device NvidiaCollectorDevice, output chan lp.CCMessage) error
 	}
 
 	if !device.excludeMetrics["nv_max_video_clock"] {
-		maxMemClock, ret := nvml.DeviceGetClockInfo(device.device, nvml.CLOCK_VIDEO)
+		maxMemClock, ret := nvml.DeviceGetMaxClockInfo(device.device, nvml.CLOCK_VIDEO)
 		if ret == nvml.SUCCESS {
 			y, err := lp.NewMessage("nv_max_video_clock", device.tags, device.meta, map[string]interface{}{"value": float64(maxMemClock)}, time.Now())
 			if err == nil {


### PR DESCRIPTION
## Summary
- ensure NVML max clocks are queried for nv_max_* metrics

## Testing
- `make fmt`
- `make vet` *(fails: Forbidden downloading github.com/klauspost/compress)*
- `go build ./...` *(fails: Forbidden downloading github.com/klauspost/compress)*

------
https://chatgpt.com/codex/tasks/task_e_683f5b3a4f2c832098c6a69ddbf35c73